### PR TITLE
fix: `loadBalancerSourceRanges` default value

### DIFF
--- a/charts/regatta/Chart.yaml
+++ b/charts/regatta/Chart.yaml
@@ -12,5 +12,5 @@ maintainers:
 - name: "Regatta Developers"
   email: "regatta@jamf.com"
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "0.1.0"

--- a/charts/regatta/values.yaml
+++ b/charts/regatta/values.yaml
@@ -165,7 +165,7 @@ api:
 
     # -- loadBalancerSourceRanges: external access whitelist, available on AWS only
     ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#aws-nlb-support
-    loadBalancerSourceRanges: {}
+    loadBalancerSourceRanges: []
     # - 0.0.0.0/0
 
 # -- metricsPort: Regatta metrics port
@@ -302,7 +302,7 @@ maintenance:
 
       # -- issuerRef: issuerRef configuration that is passed to the Certificate object
       #   Note: Applicable only if `mode: certificate`
-      issuerRef: { }
+      issuerRef: {}
       # Example issuerRef configuration:
       #   kind: ClusterIssuer
       #   name: issuer-name


### PR DESCRIPTION
`api.externalLoadBalancer.loadBalancerSourceRanges` must be of type list, not map.